### PR TITLE
Change Adventure League Campaign Badge Abbr.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1292,7 +1292,7 @@ Sent to un-like the world.
 
 | Abbreviation | Name
 | ------------ | ----
-| adv          | Adventure League
+| avd          | Adventure League
 | clr          | Colorful
 | end          | Endurance
 | ffs          | Fractured Fingers


### PR DESCRIPTION
Change Adventure League Badge Abbreviation from "adv" to "avd".